### PR TITLE
Change AxMsRdpClient version

### DIFF
--- a/src/msrdcax/AxMsRdpClient.cs
+++ b/src/msrdcax/AxMsRdpClient.cs
@@ -2,7 +2,7 @@
 
 namespace MsRdcAx
 {
-    internal class AxMsRdpClient : AxMsRdpClient10NotSafeForScripting
+    internal class AxMsRdpClient : AxMsRdpClient9NotSafeForScripting
     {
         public AxMsRdpClient() : base()
         {


### PR DESCRIPTION
AxMsRdpClient9NotSafeForScripting is the most compatible version at this time.
It works on the following OSs:
- Windows 11 22H2
- Windows 11 21H2
- Windows 10 22H2 x64
- Windows 10 22H2 x86
- Windows Server 2022
- Windows Server 2019
- Windows Server 2016
- Windows Server 2012 R2